### PR TITLE
chore: クラス名としてtwitterのwidgetで使用される名前を許可する

### DIFF
--- a/src/components/Timeline/index.tsx
+++ b/src/components/Timeline/index.tsx
@@ -17,6 +17,7 @@ const Timeline = () => {
   }, []);
   return (
     <a
+      // eslint-disable-next-line tailwindcss/no-custom-classname
       className="twitter-timeline"
       data-width="370"
       data-height="365"


### PR DESCRIPTION
`yarn build` で警告が出ていたけどここは仕方ないと思うので許容します