### PR TITLE
feat: complete時にUIを開くように変更する

### DIFF
--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -36,7 +36,24 @@ function Layout({ children, withOverflowHidden }: LayoutProps) {
 
   useEffect(() => {
     if (router) {
-      const handleRouteChange = (url: string, { shallow }: { shallow: boolean }) => {
+      const handleRouteChangeStart = (url: string, { shallow }: { shallow: boolean }) => {
+        console.log(`App is changing to ${url} ${shallow ? 'with' : 'without'} shallow routing`);
+        redApi.start({
+          to: {
+            clipPath: redIsUpside
+              ? `polygon(${100}% ${0}%, ${200}% ${100}%, ${100}% ${200}%, ${0}% ${100}%)`
+              : `polygon(${0}% ${-100}%, ${100}% ${0}%, ${0}% ${100}%, ${-100}% ${0}%)`
+          }
+        });
+        blueApi.start({
+          to: {
+            clipPath: redIsUpside
+              ? `polygon(${0}% ${-100}%, ${100}% ${0}%, ${0}% ${100}%, ${-100}% ${0}%)`
+              : `polygon(${100}% ${0}%, ${200}% ${100}%, ${100}% ${200}%, ${0}% ${100}%)`
+          }
+        });
+      };
+      const handleRouteChangeComplete = (url: string, { shallow }: { shallow: boolean }) => {
         console.log(`App is changing to ${url} ${shallow ? 'with' : 'without'} shallow routing`);
         redApi.start({
           to: {
@@ -61,10 +78,12 @@ function Layout({ children, withOverflowHidden }: LayoutProps) {
           }
         });
       };
-      router.events.on('routeChangeStart', handleRouteChange);
+      router.events.on('routeChangeStart', handleRouteChangeStart);
+      router.events.on('routeChangeComplete', handleRouteChangeComplete);
       return () => {
         setRedIsUpside((r) => !r);
-        router.events.off('routeChangeStart', handleRouteChange);
+        router.events.off('routeChangeStart', handleRouteChangeStart);
+        router.events.off('routeChangeComplete', handleRouteChangeComplete);
       };
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
現在 `routeChangeStart` イベントを使って左上、右下の要素をスワップするようなアニメーションをしていますが、`routeChangeStart` は読み込みが終了するまで待つようなものではないので、画面遷移が終了した後にアニメーションが終了した場合、とても不自然な画面遷移となってしまいます。

今回、`routeChangeStart` は閉じるところまでで、`routeChangeComplete` で開くように変更しました。これにより、上記の問題は回避できるようになったかと思います。