### PR TITLE
ci: キャッシュキーの修正

### DIFF
--- a/.github/workflows/cf-pages.yml
+++ b/.github/workflows/cf-pages.yml
@@ -36,14 +36,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
 
-      - uses: actions/cache@v3
-        id: dot-next-cache
-        with:
-          path: |
-            ${{ github.workspace }}/.next
-          key: ${{ runner.os }}-next-dir-${{ hashFiles('src/**/*') }}-${{ hashFiles('public/**/*') }}
-          restore-keys: |
-            ${{ runner.os }}-next-dir-
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
 
       - uses: actions/cache@v3
         id: next-export-optimize-images-cache
@@ -54,8 +48,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-next-export-optimize-images-cache-
 
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
+      - uses: actions/cache@v3
+        id: dot-next-cache
+        with:
+          path: |
+            ${{ github.workspace }}/.next
+          key: ${{ runner.os }}-next-dir-${{ hashFiles('src/**/*') }}-${{ hashFiles('public/**/*') }}
+          restore-keys: |
+            ${{ runner.os }}-next-dir-
 
       - name: Build
         run: yarn export


### PR DESCRIPTION
まず、出力結果のキャッシュの保存自体は正しくできていた様子。debugビルドで確認できた↓
https://github.com/vs-matsuoka/aska/actions/runs/4965460041/jobs/8886674337

同じく `node_modules/.cache` に展開されているようにも見えたが、その後のステップの `yarn install` によってこれが削除されている様子だった。

なので、`yarn` のステップをキャッシュのリストア後に行うように変更しました。これによっていい感じにキャッシュが効くようになりました :tada: これまで15分かかってたビルドが1分で済むようになりました！！！！！！