### PR TITLE
fix: スプラッシュスクリーン時は子要素を後ろに隠す

### DIFF
--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -164,7 +164,7 @@ function Layout({ children, withOverflowHidden, withSplash }: LayoutProps) {
         }}
       >
         <div className="pt-16"></div>
-        <div className={`relative flex items-center justify-center ${onSplash ? 'invisible' : ''}`} data-testid="children">
+        <div className={`relative flex items-center justify-center ${onSplash ? 'invisible -z-50' : ''}`} data-testid="children">
           {children}
         </div>
         <div className="absolute"></div>


### PR DESCRIPTION
一旦これで良さそうに見えたのでpagesにあげて試してみる