### PR TITLE
feat: なんらかの理由でrouterがエラーを吐いた場合に対応するため、とりあえず routeChangeError の場合も赤青は開くようにする

### DIFF
--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -125,9 +125,11 @@ function Layout({ children, withOverflowHidden, withSplash }: LayoutProps) {
       };
       router.events.on('routeChangeStart', handleRouteChangeStart);
       router.events.on('routeChangeComplete', handleRouteChangeComplete);
+      router.events.on('routeChangeError', handleRouteChangeComplete);
       return () => {
         router.events.off('routeChangeStart', handleRouteChangeStart);
         router.events.off('routeChangeComplete', handleRouteChangeComplete);
+        router.events.off('routeChangeError', handleRouteChangeComplete);
       };
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
連打などによってリクエストがキャンセルされたタイミングでレスポンスがキャッシュされてしまうと `routeChangeComplete` の代わりに `routeChangeError` しか吐かないようになってしまう様子だった

ので、`routeChangeError` でも赤青を開くようにしました　たぶんこれで治るはず……