### PR TITLE
fix: entriesとpairsページでのモーダル内の画像自体にkeyを指定する

### DIFF
--- a/src/components/ResponsiveImage/__snapshots__/test.tsx.snap
+++ b/src/components/ResponsiveImage/__snapshots__/test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<ResponsiveImage /> should render the heading 1`] = `
 <div
-  class=" relative"
+  class="relative"
   style="width: 25vw; height: 5.46875vw; object-fit: cover;"
 >
   <img

--- a/src/components/ResponsiveImage/index.tsx
+++ b/src/components/ResponsiveImage/index.tsx
@@ -1,14 +1,17 @@
+import classNames from 'classnames';
 import Image, { ImageProps } from 'next/image';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, Key } from 'react';
 
 function ResponsiveImage(
   props: Omit<ImageProps, 'fill' | 'width' | 'height'> & {
     width: number;
     height: number;
     alwaysResponsive?: boolean;
+    innerKey?: Key | null;
+    innerClassName?: string;
   }
 ) {
-  const { alwaysResponsive, width, height, src, alt, className, ...imageProps } = props;
+  const { alwaysResponsive, width, height, src, alt, className, innerKey, innerClassName, ...imageProps } = props;
   const standard = 1920;
   // useMediaQuery だとクライアントサイドでのレンダリング時に
   // const isNarrow = useMediaQuery({ query: '(min-width: 1920px)' });
@@ -25,19 +28,19 @@ function ResponsiveImage(
   const isFixedWidth = alwaysResponsive ? false : isNarrow;
 
   if (width === standard) {
-    return <Image src={src} alt={alt} width={width} height={height} {...imageProps} />;
+    return <Image src={src} alt={alt} width={width} height={height} className={classNames(innerClassName)} {...imageProps} {...(innerKey ? { key: innerKey } : {})} />;
   }
 
   return (
     <div
-      className={`${className ?? ''} relative`}
+      className={classNames('relative', className)}
       style={{
         width: isFixedWidth ? `${width}px` : `${(width / standard) * 100}vw`,
         height: isFixedWidth ? `${height}px` : `${(height / standard) * 100}vw`,
         objectFit: 'cover'
       }}
     >
-      <Image src={src} alt={alt} className="max-w-none" fill sizes={`${width}px`} {...imageProps}></Image>
+      <Image src={src} alt={alt} className={classNames('max-w-none', innerClassName)} fill sizes={`${width}px`} {...imageProps} {...(innerKey ? { key: innerKey } : {})}></Image>
     </div>
   );
 }

--- a/src/components/TeamItem/__snapshots__/test.tsx.snap
+++ b/src/components/TeamItem/__snapshots__/test.tsx.snap
@@ -8,7 +8,7 @@ exports[`<TeamItem /> should render correctly 1`] = `
     class="absolute ml-[-0.2083333333vw] mt-[-0.2083333333vw] 4xl:ml-[-4px] 4xl:mt-[-4px]"
   >
     <div
-      class=" relative"
+      class="relative"
       style="width: 16.666666666666664vw; height: 7.291666666666667vw; object-fit: cover;"
     >
       <img
@@ -34,7 +34,7 @@ exports[`<TeamItem /> should render correctly 1`] = `
         class="flex"
       >
         <div
-          class=" relative"
+          class="relative"
           style="width: 5.416666666666667vw; height: 5.416666666666667vw; object-fit: cover;"
         >
           <img
@@ -78,7 +78,7 @@ exports[`<TeamItem /> should render correctly 1`] = `
       target="_blank"
     >
       <div
-        class=" relative"
+        class="relative"
         style="width: 2.083333333333333vw; height: 2.083333333333333vw; object-fit: cover;"
       >
         <img
@@ -100,7 +100,7 @@ exports[`<TeamItem /> should render correctly 1`] = `
       target="_blank"
     >
       <div
-        class=" relative"
+        class="relative"
         style="width: 2.083333333333333vw; height: 2.083333333333333vw; object-fit: cover;"
       >
         <img

--- a/src/pages/entries.tsx
+++ b/src/pages/entries.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import Link from 'next/link';
 import { ReactElement, useCallback, useEffect, useState } from 'react';
 import { useSpring, animated } from 'react-spring';
@@ -30,14 +31,14 @@ function ContestantButton({ entry, onModalOpen }: { entry: Entry; onModalOpen: (
   return (
     <div key={entry.index} className="relative h-[7.8125vw] w-[4.6875vw] skew-y-[10deg] 4xl:h-[150px] 4xl:w-[90px]">
       <div className="h-[7.2916666667vw] w-[6.3541666667vw] skew-x-[-20deg] skew-y-[-11deg] bg-transparent 4xl:h-[140px] 4xl:w-[122px]"></div>
-      <a {...(entry.frameSrc.includes('Secret') ? {} : { href: '#' })}>
+      <a {...(entry.isPublished ? { href: '#' } : {})}>
         <div
           className="absolute left-[-3.28125vw] top-[-2.9687557vw] max-w-none 4xl:left-[-63px] 4xl:top-[-57px]"
           style={{
             clipPath: 'polygon(34% 25%, 88% 15%, 66% 75%, 12% 85%)'
           }}
           onClick={() => {
-            if (entry.frameSrc.includes('Secret')) {
+            if (!entry.isPublished) {
               return;
             }
             setEntry(entry);
@@ -49,7 +50,7 @@ function ContestantButton({ entry, onModalOpen }: { entry: Entry; onModalOpen: (
             className="absolute left-[3.125vw] top-[2.65625vw] h-[7.8125vw] w-[6.7708333333vw] skew-x-[-20deg] skew-y-[-11deg] bg-white 4xl:left-[60px] 4xl:top-[51px] 4xl:h-[150px] 4xl:w-[130px]"
             style={styles}
             onMouseEnter={() => {
-              if (entry.frameSrc.includes('Secret')) {
+              if (!entry.isPublished) {
                 return;
               }
               setEntry(entry);
@@ -110,13 +111,13 @@ function ToggleEntryButton() {
   }, [api]);
 
   return (
-    <div className="absolute right-[2.5vw] bottom-[-6.6666666667vw] 4xl:right-[48px] 4xl:bottom-[-128px]">
+    <div className="absolute bottom-[-6.6666666667vw] right-[2.5vw] 4xl:bottom-[-128px] 4xl:right-[48px]">
       <ResponsiveImage alt="conbi" src="/Entry/21_Entry_text_02_base.png" width={480} height={105} />
       <Link href="/pairs" passHref>
-        <div className="absolute top-0 left-0 transition hover:scale-125" onMouseEnter={trigger}>
+        <div className="absolute left-0 top-0 transition hover:scale-125" onMouseEnter={trigger}>
           <ResponsiveImage alt="conbi" src="/Entry/21_Entry_text_02.png" width={480} height={105} />
           <animated.div
-            className="absolute top-0 left-0"
+            className="absolute left-0 top-0"
             style={{
               filter: 'brightness(0) invert(1)',
               ...styles
@@ -146,6 +147,7 @@ function ContestantModal({ isOpen, onClose }: { isOpen: boolean; onClose: () => 
   }, [entry]);
   const nextEntry = searchNextPublished(entries, entry);
   const prevEntry = searchPrevPublished(entries, entry);
+  const [effect, setEffect] = useState(false);
   return (
     <div className={`fixed inset-0 ${isOpen ? 'opacity-100' : 'opacity-0'} transition-all duration-200 ${isOpen ? '' : 'pointer-events-none'}`}>
       {/*
@@ -157,8 +159,8 @@ function ContestantModal({ isOpen, onClose }: { isOpen: boolean; onClose: () => 
           .filter((entry) => entry.isPublished)
           .map((entry) => (
             <div key={entry.index}>
-              <ResponsiveImage src={entry.contestantSrc} alt="contestant" width={600} height={700} priority key={`${entry.name}-illust`} />
-              <ResponsiveImage src={entry.iconSrc} alt="icon" width={680} height={100} priority key={`${entry.name}-icon`} />
+              <ResponsiveImage src={entry.contestantSrc} alt="contestant" width={600} height={700} priority innerKey={`${entry.name}-illust`} />
+              <ResponsiveImage src={entry.iconSrc} alt="icon" width={680} height={100} priority innerKey={`${entry.name}-icon`} />
             </div>
           ))}
       </FireOnlyOnServerSide>
@@ -192,14 +194,22 @@ function ContestantModal({ isOpen, onClose }: { isOpen: boolean; onClose: () => 
               </div>
             </a>
             <div className="flex">
-              <ResponsiveImage src={entry.contestantSrc} className="animate-fade-in-from-left" alt="contestant" width={600} height={700} priority key={`${entry.name}-illust`} />
+              <ResponsiveImage
+                src={entry.contestantSrc}
+                innerClassName={classNames('animate-fade-in-from-left')}
+                alt="contestant"
+                width={600}
+                height={700}
+                priority
+                innerKey={`${entry.name}-illust`}
+              />
               <div className="my-auto h-auto">
                 <div className="absolute right-[5.8854166667vw] top-[2.2395833333vw] 4xl:right-[113px] 4xl:top-[43px]" onClick={onClose}>
                   <a href="#">
                     <ResponsiveImage src="/Modal/22_Modal_Close.png" alt="close" width={55} height={55} quality={100} />
                   </a>
                 </div>
-                <ResponsiveImage src={entry.iconSrc} alt="icon" width={680} height={100} priority key={`${entry.name}-icon`} />
+                <ResponsiveImage src={entry.iconSrc} alt="icon" width={680} height={100} priority innerKey={`${entry.name}-icon`} />
                 <ResponsiveImage src="/Modal/22_Entry_pic_Line.png" alt="line" width={725} height={10} />
                 {/* テキストサイズを決定する */}
                 <div

--- a/src/pages/pairs.tsx
+++ b/src/pages/pairs.tsx
@@ -30,14 +30,14 @@ function PairButton({ pair, onModalOpen }: { pair: Pair; onModalOpen: () => void
   return (
     <div key={pair.frameSrc} className="relative h-[7.8125vw] w-[9.375vw] skew-y-[10deg] 4xl:h-[150px] 4xl:w-[180px]">
       <div className="h-[7.2916666667vw] w-[12.7083333334vw] skew-x-[-20deg] skew-y-[-11deg] bg-transparent 4xl:h-[140px] 4xl:w-[244px]"></div>
-      <a {...(pair.frameSrc.includes('Secret') ? {} : { href: '#' })}>
+      <a {...(pair.isPublished ? { href: '#' } : {})}>
         <div
           className="absolute left-[-3.28125vw] top-[-2.9687557vw] max-w-none 4xl:left-[-63px] 4xl:top-[-57px]"
           style={{
             clipPath: 'polygon(16% 26%, 100% 1%, 84% 74%, 0 98%)'
           }}
           onClick={() => {
-            if (pair.frameSrc?.includes('Secret')) {
+            if (!pair.isPublished) {
               return;
             }
             setPair(pair);
@@ -49,7 +49,7 @@ function PairButton({ pair, onModalOpen }: { pair: Pair; onModalOpen: () => void
             className="absolute left-[1.8229166667vw] top-[1.5104166667vw] h-[7.8125vw] w-[13.5416666666vw] skew-x-[-20deg] skew-y-[-11deg] bg-white 4xl:left-[35px] 4xl:top-[29px] 4xl:h-[150px] 4xl:w-[260px]"
             style={styles}
             onMouseEnter={() => {
-              if (pair.frameSrc.includes('Secret')) {
+              if (!pair.isPublished) {
                 return;
               }
               setPair(pair);
@@ -110,13 +110,13 @@ function ToggleEntriesButton() {
   }, [api]);
 
   return (
-    <div className="absolute right-[4.1666666667vw] bottom-[-5.46875vw] 4xl:right-[80px] 4xl:bottom-[-105px]">
+    <div className="absolute bottom-[-5.46875vw] right-[4.1666666667vw] 4xl:bottom-[-105px] 4xl:right-[80px]">
       <ResponsiveImage alt="conbi" src="/Pair/31_Pair_text_02_base.png" width={500} height={105} />
       <Link href="/entries" passHref>
-        <div className="absolute top-0 left-0 transition hover:scale-125" onMouseEnter={trigger}>
+        <div className="absolute left-0 top-0 transition hover:scale-125" onMouseEnter={trigger}>
           <ResponsiveImage alt="conbi" src="/Pair/31_Pair_text_02.png" width={500} height={105} />
           <animated.div
-            className="absolute top-0 left-0"
+            className="absolute left-0 top-0"
             style={{
               filter: 'brightness(0) invert(1)',
               ...styles
@@ -157,10 +157,10 @@ function PairModal({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }
           .filter((pair) => pair.isPublished)
           .map((pair) => (
             <div key={pair.index}>
-              <ResponsiveImage src={pair.illustSrc} alt="pair" width={600} height={600} priority key={`${pair.name}-illust`} />
-              <ResponsiveImage src={pair.nameSrc} alt="icon" width={690} height={90} priority key={`${pair.name}-icon`} />
-              <ResponsiveImage src={pair.hnASrc} alt="name" width={325} height={50} key={`${pair.name}-hnA`} />
-              <ResponsiveImage src={pair.hnBSrc} alt="name" width={325} height={50} key={`${pair.name}-hnB`} />
+              <ResponsiveImage src={pair.illustSrc} alt="pair" width={600} height={600} priority innerKey={`${pair.name}-illust`} />
+              <ResponsiveImage src={pair.nameSrc} alt="icon" width={690} height={90} priority innerKey={`${pair.name}-icon`} />
+              <ResponsiveImage src={pair.hnASrc} alt="name" width={325} height={50} innerKey={`${pair.name}-hnA`} />
+              <ResponsiveImage src={pair.hnBSrc} alt="name" width={325} height={50} innerKey={`${pair.name}-hnB`} />
             </div>
           ))}
       </FireOnlyOnServerSide>
@@ -194,7 +194,7 @@ function PairModal({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }
             </a>
             <div className="flex">
               <div className="my-auto h-auto">
-                <ResponsiveImage src={pair.illustSrc} alt="pair" className="animate-fade-in-from-left" width={600} height={600} priority key={`${pair.name}-illust`} />
+                <ResponsiveImage src={pair.illustSrc} alt="pair" innerClassName="animate-fade-in-from-left" width={600} height={600} priority innerKey={`${pair.name}-illust`} />
               </div>
               <div className="my-auto h-auto">
                 <div className="absolute right-[5.8854166667vw] top-[2.2395833333vw] 4xl:right-[113px] 4xl:top-[43px]" onClick={onClose}>
@@ -204,11 +204,11 @@ function PairModal({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }
                 </div>
                 <div className="mb-[0.4166666667vw] 4xl:mb-[8px]">
                   <div className="mb-[0.3125vw] 4xl:mb-[6px]">
-                    <ResponsiveImage src={pair.nameSrc} alt="icon" width={690} height={90} priority key={`${pair.name}-icon`} />
+                    <ResponsiveImage src={pair.nameSrc} alt="icon" width={690} height={90} priority innerKey={`${pair.name}-icon`} />
                   </div>
                   <div className="ml-[0.3645833333vw] flex gap-[0.7291666667vw] 4xl:ml-[7px] 4xl:gap-[14px]">
-                    <ResponsiveImage src={pair.hnASrc} alt="name" width={325} height={50} priority key={`${pair.name}-hnA`} />
-                    <ResponsiveImage src={pair.hnBSrc} alt="name" width={325} height={50} priority key={`${pair.name}-hnB`} />
+                    <ResponsiveImage src={pair.hnASrc} alt="name" width={325} height={50} priority innerKey={`${pair.name}-hnA`} />
+                    <ResponsiveImage src={pair.hnBSrc} alt="name" width={325} height={50} priority innerKey={`${pair.name}-hnB`} />
                   </div>
                 </div>
                 <ResponsiveImage src="/Pair_Modal/32_Pair_Modal_pic_Line.png" alt="line" width={685} height={10} />
@@ -270,7 +270,7 @@ const Pairs: NextPageWithLayout = () => {
           {/* <Head></Head> */}
           <div className="relative my-auto h-[46.875vw] w-[82.8125vw] 4xl:h-[900px] 4xl:w-[1590px]">
             <div className="relative">
-              <div className="absolute top-[10vw] left-[1.6666666667vw] 4xl:top-[192px] 4xl:left-[32px]">
+              <div className="absolute left-[1.6666666667vw] top-[10vw] 4xl:left-[32px] 4xl:top-[192px]">
                 <div className="absolute left-[0.2604166667vw] top-[-12.1354166667vw] 4xl:left-[5px] 4xl:top-[-233px]">
                   <ResponsiveImage alt="pair" src="/Pair/31_Pair_text_01.png" width={500} height={250} />
                 </div>


### PR DESCRIPTION
出場者ページ、コンビページのモーダルの各画像に対して、div要素自体にではなく中の画像に対してkeyを指定するようにします。

現状の構成では、画像を持つdiv要素に対してkeyを指定していますが、自分のmacbookの環境で以下の問題が発生しました。上記対応では、これを解決します。

- 画像が読み込まれるまでの間、divが表示されず、レイアウトシフトが発生する
- 1920px以上の環境であってもvw指定での画像が表示され、レイアウトシフトが発生する
 
https://github.com/vs-matsuoka/aska/assets/12756563/4c967d1e-59a2-4f8a-9d24-2a2e66875e00

