### PR TITLE
fix: スプラッシュ用の動画が再生終了したタイミングでも onSlpasheded() を発火する

### DIFF
--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -24,6 +24,11 @@ function Splash({ onSplashEnded }: { onSplashEnded: () => void }) {
             onSplashEnded();
           }, 1400);
         }}
+        onEnded={() => {
+          setTimeout(() => {
+            onSplashEnded();
+          }, 900);
+        }}
         onClick={() => {
           onSplashEnded();
         }}


### PR DESCRIPTION
`onEnded` でも `onSlpasheded` を発火するように変更します

ちょっと条件うまく掴めてないので、一旦蓋をするような対応になりますが、これで様子を見させてください