### PR TITLE
fix: キービジュアルのうち、animate-zeus-floatが他より優先されている用に見えたので、明示的にanimate-zeus-floatを削除するように対応

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -29,7 +29,7 @@ const Top: NextPageWithLayout = () => {
             <Image
               src="/Top/11_Top_pic_KeyVisual_Zeus.png"
               alt="zeus"
-              className={classNames('max-w-none', 'animate-zeus-float', { 'animate-redzone-left': redZone, 'animate-evans-left': evans })}
+              className={classNames('max-w-none', { 'animate-zeus-float': !redZone && !evans, 'animate-redzone-left': redZone, 'animate-evans-left': evans })}
               width={1250}
               height={1250}
             />
@@ -38,7 +38,7 @@ const Top: NextPageWithLayout = () => {
             <Image
               src="/Top/11_Top_pic_KeyVisual_Amatelas.png"
               alt="amatelas"
-              className={classNames('max-w-none', 'animate-amateras-float', { 'animate-redzone-right': redZone, 'animate-evans-right': evans })}
+              className={classNames('max-w-none', { 'animate-amateras-float': !redZone && !evans, 'animate-redzone-right': redZone, 'animate-evans-right': evans })}
               width={1250}
               height={1250}
             />


### PR DESCRIPTION
元々 `animate-zeus-float` と `animate-amateras-float` をつけたまま例のアニメーションのためのクラスを付けるようにしましたが、おそらく詳細度の差によってamateras側にしかあのアニメーションがついていない状態でした。なので、redzoneかevansが有効な間は明示的にfloatのクラスを削除するように変更しました。

↓zeusはfloatが優先的

<img width="326" alt="image" src="https://github.com/vs-matsuoka/aska/assets/12756563/9a3fe737-1e46-478a-9f30-6ca2bbdd781c">


↓amaterasはredzoneが優先的

<img width="323" alt="image" src="https://github.com/vs-matsuoka/aska/assets/12756563/e1cc875e-12a9-44c4-aaad-008b0c8f48e6">


デリキンさんに教えてもらいました: https://discord.com/channels/992825450395078787/1024251217070788648/1109441848361099264