### PR TITLE
ci: 'next build'でexportと同じことをやってくれるので'next export'を削除する

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "export": "yarn build && next export && next-export-optimize-images",
+    "export": "yarn build && next-export-optimize-images",
     "serve": "serve ./out",
     "start": "next start",
     "lint": "next lint",


### PR DESCRIPTION
`next.config.js` で `output: 'export'` を指定しているため、`next build` が `next export` 相当の動きをします。なので、現状の `yarn export` は `next export` を2回やっていることになります。これを一回のみの実行に変更します。