### PR TITLE
feat: data-nosnippetをつけてdescriptionに乗らないようにする

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -145,6 +145,7 @@ function MyApp({ Component, pageProps }: AppPropsWithLayout) {
           fontFamily: 'UDKakugo_LargePr6-HV',
           lineHeight: '1.7'
         }}
+        data-nosnippet
       >
         {UDKakugoLargePr6HVStrings}
       </div>
@@ -154,6 +155,7 @@ function MyApp({ Component, pageProps }: AppPropsWithLayout) {
           fontFamily: 'FOT-UD角ゴ_ラージ Pr6 E',
           lineHeight: '1.7'
         }}
+        data-nosnippet
       >
         {UDKakugoLargePr6EStrings}
       </div>


### PR DESCRIPTION
検索結果に文字の羅列が乗ってしまう問題がまだ解決していなかったのですが、以下の情報をもとに `data-nosnippet` をつけてスニペットとして使用されないようにしてみます

see https://developers.google.com/search/docs/appearance/snippet?hl=ja#nosnippet