### PR TITLE
fix: スプラッシュスクリーンではスクロールしないようにする

### DIFF
--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -170,7 +170,7 @@ function Layout({ children, withOverflowHidden, withSplash }: LayoutProps) {
         </header>
         <div className="pt-16"></div>
         {/* h-0 について: 想定としては overflow-hidden ですべての要素が隠れていて欲しいが、なぜかちゃんとクリップされない様子だったので、直接 h-0 を指定する */}
-        <main className={classNames(['w-full', 'h-full', { 'h-0': onSplash, invisible: onSplash }])} data-testid="children">
+        <main className={classNames(['w-full', { 'h-full': !onSplash, 'h-0': onSplash, invisible: onSplash, ['-z-50']: onSplash }])} data-testid="children">
           {children}
         </main>
       </div>


### PR DESCRIPTION
Closes #205
Closes #203

スプラッシュスクリーンが出ている間はpagesの要素を `overflow-hidden` にしておくことで、スプラッシュスクリーンの裏が何であろうと画面幅より大きな要素があってもスクロールできないようにします。

また、副次的な作用として、図らずとも #203 のコメント欄で自分が提案した挙動と同じような感じになっています。あちらの方針次第ですが、もしあのままで良いのであれば203もクローズできそう