### PR TITLE
fix: 最小の大きさがdom要素次第になっていて画面の縦幅いっぱいまで広げられていなかったので修正

### DIFF
--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -159,7 +159,7 @@ function Layout({ children, withOverflowHidden, withSplash }: LayoutProps) {
         />
       </div>
       <div
-        className={classNames('grid', 'w-full', 'h-full', { 'overflow-hidden': onSplash })}
+        className={classNames('grid', 'w-full', 'min-h-screen', { 'overflow-hidden': onSplash })}
         style={{
           gridTemplateRows: 'auto auto 1fr',
           gridTemplateColumns: '100%'


### PR DESCRIPTION
最小幅を100vwに設定し、要素が常に画面縦幅いっぱいまで広がるように設定しました。