### PR TITLE
fix: longnameの場合かつ画面幅が充分でない場合にフォントサイズが変わらない問題を修正

### DIFF
--- a/src/components/TeamItem/index.tsx
+++ b/src/components/TeamItem/index.tsx
@@ -27,7 +27,7 @@ const TeamItem = ({ member }: TeamItemProps) => (
           {member.role}
         </p>
         <p
-          className={'mt-[0.4166666667vw] text-white 4xl:mt-[8px] ' + (member.hasLongName ? 'text-[1.4583333333vw] 4xl:text-[16px]' : 'text-[1.4583333333vw] 4xl:text-[28px]')}
+          className={'mt-[0.4166666667vw] text-white 4xl:mt-[8px] ' + (member.hasLongName ? 'text-[0.8333333333vw] 4xl:text-[16px]' : 'text-[1.4583333333vw] 4xl:text-[28px]')}
           data-testid="name"
         >
           {member.name}


### PR DESCRIPTION
画面幅が小さい時
![image](https://github.com/vs-matsuoka/aska/assets/12756563/4347e2a4-bbff-4733-b1a8-d972d0e5d926)

画面幅が大きい時
![image](https://github.com/vs-matsuoka/aska/assets/12756563/a35cd596-b27b-446d-af89-33f88b404e78)
