### PR TITLE
feat: SP版で長い名前を持っている場合のフォントサイズを4.2に変更

### DIFF
--- a/src/components/SpTeamItem/index.tsx
+++ b/src/components/SpTeamItem/index.tsx
@@ -59,7 +59,7 @@ const SpTeamItem = ({ member }: { member: TeamMember }) => (
           {member.role}
         </p>
         {/* sp:ml-[15px] sp:mt-[3px] sp:text-[36px] */}
-        <p className={cls('ml-[2vw]', 'mt-[0.5333333333vw]', member.hasTooLongName ? 'text-[4.4vw]' : 'text-[4.8vw]', 'text-[#CCAD70]')} data-testid="name">
+        <p className={cls('ml-[2vw]', 'mt-[0.5333333333vw]', member.hasTooLongName ? 'text-[4.2vw]' : 'text-[4.8vw]', 'text-[#CCAD70]')} data-testid="name">
           {member.name}
         </p>
       </div>


### PR DESCRIPTION
実機環境のうち一部でまだ文字が折り返されてしまう様子なので、これをさらに調整します

![image](https://github.com/vs-matsuoka/aska/assets/12756563/3af43301-ed21-4d36-bbc7-c2c766636a67)
