### PR TITLE
フォントを FONTPLUS の UD角ゴ から Noto Sans JP (源ノ角ゴシック) に置き換え

### DIFF
--- a/src/components/Movie/__snapshots__/test.tsx.snap
+++ b/src/components/Movie/__snapshots__/test.tsx.snap
@@ -73,7 +73,7 @@ exports[`<Movie /> should render the heading 1`] = `
   <h1
     class="mt-[0.2083333333vw] text-center text-[1.71875vw] 4xl:mt-[4px] 4xl:text-[33px]"
     data-testid="title"
-    style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+    style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
   >
     第1弾告知
   </h1>

--- a/src/components/Movie/index.tsx
+++ b/src/components/Movie/index.tsx
@@ -3,6 +3,7 @@ import Image, { ImageProps } from 'next/image';
 import { useEffect, useState } from 'react';
 import ResponsiveImage from 'components/ResponsiveImage';
 import { Movie as MovieType } from 'const/movies';
+import { udKakugoLargeE } from 'libs/fonts';
 
 function MovieThumbnailResponsiveImage(
   props: Omit<ImageProps, 'fill' | 'width' | 'height'> & {
@@ -58,7 +59,7 @@ const Movie = ({ movie, onClick, onMouseEnter }: { movie: MovieType; onClick: ()
     <h1
       className="mt-[0.2083333333vw] text-center text-[1.71875vw] 4xl:mt-[4px] 4xl:text-[33px]"
       style={{
-        fontFamily: 'FOT-UD角ゴ_ラージ Pr6 E',
+        ...udKakugoLargeE,
         lineHeight: '1'
       }}
       data-testid="title"

--- a/src/components/SpTeamItem/__snapshots__/test.tsx.snap
+++ b/src/components/SpTeamItem/__snapshots__/test.tsx.snap
@@ -32,7 +32,7 @@ exports[`<SpTeamItem /> should render the heading 1`] = `
     </div>
     <div
       class="mt-[0.6666666667vw]"
-      style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+      style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
     >
       <p
         class="text-[2.6666666667vw] text-white"

--- a/src/components/SpTeamItem/index.tsx
+++ b/src/components/SpTeamItem/index.tsx
@@ -2,6 +2,7 @@ import cls from 'classnames';
 import Image, { ImageProps } from 'next/image';
 import SpResponsiveImage from 'components/SpResponsiveImage';
 import { TeamMember } from 'const/team';
+import { udKakugoLargeE } from 'libs/fonts';
 
 function ResponsiveImage(
   props: Omit<ImageProps, 'fill' | 'width' | 'height'> & {
@@ -50,7 +51,7 @@ const SpTeamItem = ({ member }: { member: TeamMember }) => (
         // sp:mt-[5px]
         className="mt-[0.6666666667vw]"
         style={{
-          fontFamily: 'FOT-UD角ゴ_ラージ Pr6 E',
+          ...udKakugoLargeE,
           lineHeight: '1'
         }}
       >

--- a/src/components/TeamItem/__snapshots__/test.tsx.snap
+++ b/src/components/TeamItem/__snapshots__/test.tsx.snap
@@ -90,7 +90,7 @@ exports[`<TeamItem /> should render correctly 1`] = `
     </div>
     <div
       class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-      style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+      style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
     >
       <p
         class="text-[0.78125vw] text-white 4xl:text-[15px]"

--- a/src/components/TeamItem/index.tsx
+++ b/src/components/TeamItem/index.tsx
@@ -1,5 +1,6 @@
 import ResponsiveImage from 'components/ResponsiveImage';
 import { TeamMember } from 'const/team';
+import { udKakugoLargeE } from 'libs/fonts';
 
 type TeamItemProps = {
   member: TeamMember;
@@ -19,7 +20,7 @@ const TeamItem = ({ member }: TeamItemProps) => (
       <div
         className="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
         style={{
-          fontFamily: 'FOT-UD角ゴ_ラージ Pr6 E',
+          ...udKakugoLargeE,
           lineHeight: '1'
         }}
       >

--- a/src/components/pages/EntriesPage/index.tsx
+++ b/src/components/pages/EntriesPage/index.tsx
@@ -9,6 +9,7 @@ import ResponsiveImage from 'components/ResponsiveImage';
 import entries, { Entry } from 'const/entries';
 import { EntryContextType, EntryProvider, useEntryContext } from 'contexts/EntryContext';
 import useModal from 'hooks/useModal';
+import { udKakugoLargeHV } from 'libs/fonts';
 import { searchNextPublished, searchPrevPublished } from 'utils/nextPrev';
 
 type ContestantRowProps = {
@@ -202,9 +203,9 @@ function ContestantModal({ isOpen, onClose }: { isOpen: boolean; onClose: () => 
                 <ResponsiveImage src="/Modal/22_Entry_pic_Line.png" alt="line" width={725} height={10} />
                 {/* テキストサイズを決定する */}
                 <div
-                  className="my-[0.5208333333vw] w-[37.7604166667vw] text-[1.3020833333vw] font-bold text-white 4xl:my-[10px] 4xl:w-[725px] 4xl:text-[25px]"
+                  className="my-[0.5208333333vw] w-[37.7604166667vw] text-[1.328125vw] font-bold text-white 4xl:my-[10px] 4xl:w-[725px] 4xl:text-[25.5px]"
                   style={{
-                    fontFamily: 'UDKakugo_LargePr6-HV',
+                    ...udKakugoLargeHV,
                     lineHeight: '1.7'
                   }}
                   dangerouslySetInnerHTML={{ __html: entry.description.replaceAll('\n', '<br />') }}

--- a/src/components/pages/MoviesPage/__snapshots__/test.tsx.snap
+++ b/src/components/pages/MoviesPage/__snapshots__/test.tsx.snap
@@ -131,7 +131,7 @@ exports[`<MoviesPage /> should render the heading 1`] = `
             <h1
               class="mt-[0.2083333333vw] text-center text-[1.71875vw] 4xl:mt-[4px] 4xl:text-[33px]"
               data-testid="title"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               出場者告知
             </h1>
@@ -183,7 +183,7 @@ exports[`<MoviesPage /> should render the heading 1`] = `
             <h1
               class="mt-[0.2083333333vw] text-center text-[1.71875vw] 4xl:mt-[4px] 4xl:text-[33px]"
               data-testid="title"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               特殊告知「流行」
             </h1>
@@ -235,7 +235,7 @@ exports[`<MoviesPage /> should render the heading 1`] = `
             <h1
               class="mt-[0.2083333333vw] text-center text-[1.71875vw] 4xl:mt-[4px] 4xl:text-[33px]"
               data-testid="title"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               前半中間告知
             </h1>
@@ -287,7 +287,7 @@ exports[`<MoviesPage /> should render the heading 1`] = `
             <h1
               class="mt-[0.2083333333vw] text-center text-[1.71875vw] 4xl:mt-[4px] 4xl:text-[33px]"
               data-testid="title"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               後半中間告知
             </h1>
@@ -339,7 +339,7 @@ exports[`<MoviesPage /> should render the heading 1`] = `
             <h1
               class="mt-[0.2083333333vw] text-center text-[1.71875vw] 4xl:mt-[4px] 4xl:text-[33px]"
               data-testid="title"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               特殊告知「アナログ」
             </h1>
@@ -420,7 +420,7 @@ exports[`<MoviesPage /> should render the heading 1`] = `
             <h1
               class="mt-[0.2083333333vw] text-center text-[1.71875vw] 4xl:mt-[4px] 4xl:text-[33px]"
               data-testid="title"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               第1弾告知
             </h1>
@@ -472,7 +472,7 @@ exports[`<MoviesPage /> should render the heading 1`] = `
             <h1
               class="mt-[0.2083333333vw] text-center text-[1.71875vw] 4xl:mt-[4px] 4xl:text-[33px]"
               data-testid="title"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               第2弾告知
             </h1>
@@ -524,7 +524,7 @@ exports[`<MoviesPage /> should render the heading 1`] = `
             <h1
               class="mt-[0.2083333333vw] text-center text-[1.71875vw] 4xl:mt-[4px] 4xl:text-[33px]"
               data-testid="title"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               第3弾告知
             </h1>
@@ -576,7 +576,7 @@ exports[`<MoviesPage /> should render the heading 1`] = `
             <h1
               class="mt-[0.2083333333vw] text-center text-[1.71875vw] 4xl:mt-[4px] 4xl:text-[33px]"
               data-testid="title"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               第4弾告知
             </h1>
@@ -628,7 +628,7 @@ exports[`<MoviesPage /> should render the heading 1`] = `
             <h1
               class="mt-[0.2083333333vw] text-center text-[1.71875vw] 4xl:mt-[4px] 4xl:text-[33px]"
               data-testid="title"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               第5弾告知
             </h1>
@@ -680,7 +680,7 @@ exports[`<MoviesPage /> should render the heading 1`] = `
             <h1
               class="mt-[0.2083333333vw] text-center text-[1.71875vw] 4xl:mt-[4px] 4xl:text-[33px]"
               data-testid="title"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               第6弾告知
             </h1>
@@ -732,7 +732,7 @@ exports[`<MoviesPage /> should render the heading 1`] = `
             <h1
               class="mt-[0.2083333333vw] text-center text-[1.71875vw] 4xl:mt-[4px] 4xl:text-[33px]"
               data-testid="title"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               第7弾告知
             </h1>
@@ -784,7 +784,7 @@ exports[`<MoviesPage /> should render the heading 1`] = `
             <h1
               class="mt-[0.2083333333vw] text-center text-[1.71875vw] 4xl:mt-[4px] 4xl:text-[33px]"
               data-testid="title"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               第8弾告知
             </h1>
@@ -836,7 +836,7 @@ exports[`<MoviesPage /> should render the heading 1`] = `
             <h1
               class="mt-[0.2083333333vw] text-center text-[1.71875vw] 4xl:mt-[4px] 4xl:text-[33px]"
               data-testid="title"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               第9弾告知
             </h1>
@@ -888,7 +888,7 @@ exports[`<MoviesPage /> should render the heading 1`] = `
             <h1
               class="mt-[0.2083333333vw] text-center text-[1.71875vw] 4xl:mt-[4px] 4xl:text-[33px]"
               data-testid="title"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               第10弾告知
             </h1>
@@ -940,7 +940,7 @@ exports[`<MoviesPage /> should render the heading 1`] = `
             <h1
               class="mt-[0.2083333333vw] text-center text-[1.71875vw] 4xl:mt-[4px] 4xl:text-[33px]"
               data-testid="title"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               第11弾告知
             </h1>
@@ -992,7 +992,7 @@ exports[`<MoviesPage /> should render the heading 1`] = `
             <h1
               class="mt-[0.2083333333vw] text-center text-[1.71875vw] 4xl:mt-[4px] 4xl:text-[33px]"
               data-testid="title"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               第12弾告知
             </h1>
@@ -1044,7 +1044,7 @@ exports[`<MoviesPage /> should render the heading 1`] = `
             <h1
               class="mt-[0.2083333333vw] text-center text-[1.71875vw] 4xl:mt-[4px] 4xl:text-[33px]"
               data-testid="title"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               第13弾告知
             </h1>
@@ -1096,7 +1096,7 @@ exports[`<MoviesPage /> should render the heading 1`] = `
             <h1
               class="mt-[0.2083333333vw] text-center text-[1.71875vw] 4xl:mt-[4px] 4xl:text-[33px]"
               data-testid="title"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               第14弾告知
             </h1>
@@ -1148,7 +1148,7 @@ exports[`<MoviesPage /> should render the heading 1`] = `
             <h1
               class="mt-[0.2083333333vw] text-center text-[1.71875vw] 4xl:mt-[4px] 4xl:text-[33px]"
               data-testid="title"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               第15弾告知
             </h1>
@@ -1200,7 +1200,7 @@ exports[`<MoviesPage /> should render the heading 1`] = `
             <h1
               class="mt-[0.2083333333vw] text-center text-[1.71875vw] 4xl:mt-[4px] 4xl:text-[33px]"
               data-testid="title"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               第16弾告知
             </h1>
@@ -1252,7 +1252,7 @@ exports[`<MoviesPage /> should render the heading 1`] = `
             <h1
               class="mt-[0.2083333333vw] text-center text-[1.71875vw] 4xl:mt-[4px] 4xl:text-[33px]"
               data-testid="title"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               第17弾告知
             </h1>
@@ -1304,7 +1304,7 @@ exports[`<MoviesPage /> should render the heading 1`] = `
             <h1
               class="mt-[0.2083333333vw] text-center text-[1.71875vw] 4xl:mt-[4px] 4xl:text-[33px]"
               data-testid="title"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               第18弾告知
             </h1>
@@ -1356,7 +1356,7 @@ exports[`<MoviesPage /> should render the heading 1`] = `
             <h1
               class="mt-[0.2083333333vw] text-center text-[1.71875vw] 4xl:mt-[4px] 4xl:text-[33px]"
               data-testid="title"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               第19弾告知
             </h1>
@@ -1408,7 +1408,7 @@ exports[`<MoviesPage /> should render the heading 1`] = `
             <h1
               class="mt-[0.2083333333vw] text-center text-[1.71875vw] 4xl:mt-[4px] 4xl:text-[33px]"
               data-testid="title"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               第20弾告知
             </h1>
@@ -1489,7 +1489,7 @@ exports[`<MoviesPage /> should render the heading 1`] = `
             <h1
               class="mt-[0.2083333333vw] text-center text-[1.71875vw] 4xl:mt-[4px] 4xl:text-[33px]"
               data-testid="title"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               音MDM Direct 01
             </h1>

--- a/src/components/pages/PairsPage/index.tsx
+++ b/src/components/pages/PairsPage/index.tsx
@@ -8,6 +8,7 @@ import ResponsiveImage from 'components/ResponsiveImage';
 import pairs, { Pair as Pair } from 'const/pairs';
 import { PairContextType, PairProvider, usePairContext } from 'contexts/PairContext';
 import useModal from 'hooks/useModal';
+import { udKakugoLargeHV } from 'libs/fonts';
 import { searchNextPublished, searchPrevPublished } from 'utils/nextPrev';
 
 type PairRowProps = {
@@ -213,7 +214,7 @@ function PairModal({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }
                 <div
                   className="my-[0.5208333333vw] w-[37.7604166667vw] text-[1.9270833333vw] font-bold text-white 4xl:my-[10px] 4xl:w-[725px] 4xl:text-[37px]"
                   style={{
-                    fontFamily: 'UDKakugo_LargePr6-HV',
+                    ...udKakugoLargeHV,
                     lineHeight: '1.7'
                   }}
                   dangerouslySetInnerHTML={{ __html: pair.description.replaceAll('\n', '<br />') }}

--- a/src/components/pages/TeamPage/__snapshots__/test.tsx.snap
+++ b/src/components/pages/TeamPage/__snapshots__/test.tsx.snap
@@ -145,7 +145,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -258,7 +258,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -371,7 +371,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -484,7 +484,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -597,7 +597,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -710,7 +710,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -844,7 +844,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -957,7 +957,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -1091,7 +1091,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -1204,7 +1204,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -1338,7 +1338,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -1476,7 +1476,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -1610,7 +1610,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -1723,7 +1723,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -1857,7 +1857,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -1970,7 +1970,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -2104,7 +2104,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -2217,7 +2217,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -2376,7 +2376,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -2489,7 +2489,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -2602,7 +2602,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -2715,7 +2715,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -2828,7 +2828,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -2941,7 +2941,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -3054,7 +3054,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -3167,7 +3167,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -3326,7 +3326,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -3439,7 +3439,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -3552,7 +3552,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -3665,7 +3665,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -3799,7 +3799,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -3933,7 +3933,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -4046,7 +4046,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -4180,7 +4180,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -4293,7 +4293,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -4406,7 +4406,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -4565,7 +4565,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -4699,7 +4699,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -4812,7 +4812,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -4925,7 +4925,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -5059,7 +5059,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -5193,7 +5193,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -5306,7 +5306,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -5440,7 +5440,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -5510,7 +5510,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -5644,7 +5644,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -5736,7 +5736,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -5849,7 +5849,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -5941,7 +5941,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -6075,7 +6075,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -6209,7 +6209,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -6322,7 +6322,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -6456,7 +6456,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -6590,7 +6590,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -6703,7 +6703,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -6795,7 +6795,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -6908,7 +6908,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -7021,7 +7021,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -7134,7 +7134,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -7247,7 +7247,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -7360,7 +7360,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -7494,7 +7494,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -7607,7 +7607,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -7745,7 +7745,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -7858,7 +7858,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -7992,7 +7992,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -8084,7 +8084,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -8218,7 +8218,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -8331,7 +8331,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -8444,7 +8444,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -8578,7 +8578,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -8691,7 +8691,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -8825,7 +8825,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -8938,7 +8938,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -9072,7 +9072,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -9185,7 +9185,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -9319,7 +9319,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -9453,7 +9453,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -9566,7 +9566,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -9679,7 +9679,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -9813,7 +9813,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -9947,7 +9947,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -10081,7 +10081,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -10194,7 +10194,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -10307,7 +10307,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -10441,7 +10441,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -10554,7 +10554,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -10688,7 +10688,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -10801,7 +10801,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -10935,7 +10935,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -11048,7 +11048,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -11182,7 +11182,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -11295,7 +11295,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -11408,7 +11408,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -11521,7 +11521,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -11634,7 +11634,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -11768,7 +11768,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -11881,7 +11881,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -11994,7 +11994,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -12128,7 +12128,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -12262,7 +12262,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -12375,7 +12375,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"
@@ -12488,7 +12488,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
             </div>
             <div
               class="mt-[0.7291666667vw] drop-shadow-[0_0_0.15625vw_#000000] 4xl:mt-[14px] 4xl:drop-shadow-[0_0_3px_#000000]"
-              style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+              style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
             >
               <p
                 class="text-[0.78125vw] text-white 4xl:text-[15px]"

--- a/src/components/pages/sp/EntryPage/index.tsx
+++ b/src/components/pages/sp/EntryPage/index.tsx
@@ -3,6 +3,7 @@ import Background from 'components/Background';
 import SpMenu from 'components/SpMenu';
 import SpResponsiveImage from 'components/SpResponsiveImage';
 import entries, { Entry } from 'const/entries';
+import { udKakugoLargeE } from 'libs/fonts';
 
 function getEntryIcon(entry: Entry, index: number) {
   if (entry.isPublished) {
@@ -60,7 +61,7 @@ const EntryPage = (props: EntryProps) => {
             <div
               className="absolute left-[20.6666667vw] top-[33.3333333vw] skew-y-[-10deg] text-[4vw] tracking-[.07em] text-white"
               style={{
-                fontFamily: 'FOT-UD角ゴ_ラージ Pr6 E',
+                ...udKakugoLargeE,
                 lineHeight: '1.3'
               }}
               dangerouslySetInnerHTML={{ __html: props.description.replaceAll('\n', '<br />') }}

--- a/src/components/pages/sp/MoviesPage/index.tsx
+++ b/src/components/pages/sp/MoviesPage/index.tsx
@@ -4,6 +4,7 @@ import Background from 'components/Background';
 import SpMenu from 'components/SpMenu';
 import SpResponsiveImage from 'components/SpResponsiveImage';
 import movies, { Movie } from 'const/movies';
+import { udKakugoLargeE } from 'libs/fonts';
 
 function MovieThumbnailResponsiveImage(
   props: Omit<ImageProps, 'fill' | 'width' | 'height'> & {
@@ -47,7 +48,7 @@ const MovieCard = ({ item, index }: { item: Movie; index: number }) => {
       <div
         className="mt-[1.3333333vw] grid justify-items-center"
         style={{
-          fontFamily: 'FOT-UD角ゴ_ラージ Pr6 E',
+          ...udKakugoLargeE,
           lineHeight: '1'
         }}
       >
@@ -73,7 +74,7 @@ export default function MoviesPage() {
         <h1
           className="flex justify-center pt-[3.6vw]"
           style={{
-            fontFamily: 'FOT-UD角ゴ_ラージ Pr6 E',
+            ...udKakugoLargeE,
             lineHeight: '1'
           }}
         >
@@ -93,7 +94,7 @@ export default function MoviesPage() {
         <h1
           className="flex justify-center pt-[3.3333333vw]"
           style={{
-            fontFamily: 'FOT-UD角ゴ_ラージ Pr6 E',
+            ...udKakugoLargeE,
             lineHeight: '1'
           }}
         >
@@ -113,7 +114,7 @@ export default function MoviesPage() {
         <h1
           className="flex justify-center pt-[3.3333333vw]"
           style={{
-            fontFamily: 'FOT-UD角ゴ_ラージ Pr6 E',
+            ...udKakugoLargeE,
             lineHeight: '1'
           }}
         >

--- a/src/components/pages/sp/TeamPage/__snapshots__/test.tsx.snap
+++ b/src/components/pages/sp/TeamPage/__snapshots__/test.tsx.snap
@@ -31,7 +31,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
       >
         <div
           class="m-auto text-center align-middle text-[4.8vw]"
-          style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+          style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
         >
           運　営
         </div>
@@ -67,7 +67,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -187,7 +187,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -307,7 +307,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -427,7 +427,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -547,7 +547,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -667,7 +667,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -789,7 +789,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -909,7 +909,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -1031,7 +1031,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -1151,7 +1151,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -1273,7 +1273,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -1369,7 +1369,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
       >
         <div
           class="m-auto text-center align-middle text-[4.8vw]"
-          style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+          style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
         >
           制　作
         </div>
@@ -1405,7 +1405,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -1527,7 +1527,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -1647,7 +1647,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -1769,7 +1769,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -1889,7 +1889,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -2011,7 +2011,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -2131,7 +2131,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -2229,7 +2229,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
       >
         <div
           class="m-auto text-center align-middle text-[4.8vw]"
-          style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+          style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
         >
           立ち絵
         </div>
@@ -2265,7 +2265,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -2385,7 +2385,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -2505,7 +2505,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -2625,7 +2625,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -2745,7 +2745,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -2865,7 +2865,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -2985,7 +2985,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -3105,7 +3105,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -3203,7 +3203,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
       >
         <div
           class="m-auto text-center align-middle text-[4.8vw]"
-          style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+          style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
         >
           告　知
         </div>
@@ -3239,7 +3239,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -3359,7 +3359,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -3479,7 +3479,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -3599,7 +3599,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -3721,7 +3721,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -3843,7 +3843,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -3963,7 +3963,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -4085,7 +4085,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -4205,7 +4205,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -4325,7 +4325,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -4423,7 +4423,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
       >
         <div
           class="m-auto text-center align-middle text-[4.8vw]"
-          style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+          style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
         >
           放　送
         </div>
@@ -4459,7 +4459,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -4581,7 +4581,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -4701,7 +4701,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -4821,7 +4821,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -4943,7 +4943,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -5065,7 +5065,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -5185,7 +5185,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -5307,7 +5307,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -5423,7 +5423,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -5545,7 +5545,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -5663,7 +5663,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -5783,7 +5783,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -5901,7 +5901,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -6023,7 +6023,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -6145,7 +6145,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -6265,7 +6265,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -6387,7 +6387,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -6509,7 +6509,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -6629,7 +6629,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -6747,7 +6747,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -6867,7 +6867,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -6987,7 +6987,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -7107,7 +7107,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -7227,7 +7227,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -7347,7 +7347,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -7469,7 +7469,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -7589,7 +7589,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -7685,7 +7685,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
       >
         <div
           class="m-auto text-center align-middle text-[4.8vw]"
-          style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+          style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
         >
           特　番
         </div>
@@ -7721,7 +7721,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -7841,7 +7841,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -7963,7 +7963,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -8081,7 +8081,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -8203,7 +8203,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -8323,7 +8323,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -8443,7 +8443,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -8565,7 +8565,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -8685,7 +8685,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -8807,7 +8807,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -8927,7 +8927,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -9049,7 +9049,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -9169,7 +9169,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -9291,7 +9291,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -9413,7 +9413,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -9533,7 +9533,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -9653,7 +9653,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -9775,7 +9775,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -9897,7 +9897,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -10019,7 +10019,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -10139,7 +10139,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -10259,7 +10259,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -10381,7 +10381,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -10501,7 +10501,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -10623,7 +10623,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -10743,7 +10743,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -10865,7 +10865,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -10985,7 +10985,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -11107,7 +11107,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -11227,7 +11227,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -11347,7 +11347,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -11467,7 +11467,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -11587,7 +11587,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -11709,7 +11709,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -11829,7 +11829,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -11949,7 +11949,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -12071,7 +12071,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -12193,7 +12193,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -12313,7 +12313,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"
@@ -12433,7 +12433,7 @@ exports[`<TeamPage /> should render the heading 1`] = `
           </div>
           <div
             class="mt-[0.6666666667vw]"
-            style="font-family: FOT-UD角ゴ_ラージ Pr6 E; line-height: 1;"
+            style="font-family: fontFamily; font-weight: 800; font-feature-settings: 'palt'; line-height: 1;"
           >
             <p
               class="text-[2.6666666667vw] text-white"

--- a/src/components/pages/sp/TeamPage/index.tsx
+++ b/src/components/pages/sp/TeamPage/index.tsx
@@ -3,6 +3,7 @@ import Background from 'components/Background';
 import SpMenu from 'components/SpMenu';
 import SpTeamItem from 'components/SpTeamItem';
 import team from 'const/team';
+import { udKakugoLargeE } from 'libs/fonts';
 
 function SpTeamHeader({ children }: { children: ReactNode }) {
   return (
@@ -12,7 +13,7 @@ function SpTeamHeader({ children }: { children: ReactNode }) {
       <div
         className="m-auto text-center align-middle text-[4.8vw]"
         style={{
-          fontFamily: 'FOT-UD角ゴ_ラージ Pr6 E',
+          ...udKakugoLargeE,
           lineHeight: '1'
         }}
       >

--- a/src/libs/fonts.ts
+++ b/src/libs/fonts.ts
@@ -1,0 +1,30 @@
+import { Noto_Sans_JP } from 'next/font/google';
+import type { CSSProperties } from 'react';
+
+// 源ノ角ゴシック (Source Han Sans) の Google Fonts 配布版。
+// 可変フォントなので fontWeight は 100〜900 の任意の値を指定できる。
+export const notoSansJp = Noto_Sans_JP({
+  subsets: ['latin'],
+  display: 'swap'
+});
+
+// 'palt' は約物 (記号類)・かなをプロポーショナル幅に詰める OpenType 機能。
+// 記号類だけ詰めたい場合は 'halt' に変える。
+const tsume = "'palt'";
+
+// 旧 FOT-UD角ゴ_ラージ Pr6 E 相当
+export const udKakugoLargeE: CSSProperties = {
+  fontFamily: notoSansJp.style.fontFamily,
+  fontWeight: 800,
+  fontFeatureSettings: tsume
+};
+
+// 旧 FOT-UD角ゴ_ラージ Pr6 HV (Heavy) 相当。
+// 900 が可変軸の上限なので、text-stroke で文字色の縁取りを足してわずかに太らせている。
+// 太さの追い込みは WebkitTextStrokeWidth (em 単位なので文字サイズに追従) で行う。
+export const udKakugoLargeHV: CSSProperties = {
+  fontFamily: notoSansJp.style.fontFamily,
+  fontWeight: 900,
+  fontFeatureSettings: tsume,
+  WebkitTextStrokeWidth: '0.01em'
+};

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -8,11 +8,8 @@ import { ParallaxProvider } from 'react-scroll-parallax';
 import urlJoin from 'url-join';
 import * as gtag from '../utils/gtag';
 import GaScript from 'components/GaScript';
-import entries from 'const/entries';
-import movies from 'const/movies';
-import pairs from 'const/pairs';
 import phrases, { otomdmTenCom } from 'const/phrases';
-import team from 'const/team';
+import { notoSansJp } from 'libs/fonts';
 
 export type NextPageWithLayout<P = {}, IP = P> = NextPage<P, IP> & {
   getLayout?: (page: ReactElement) => ReactNode;
@@ -21,38 +18,6 @@ export type NextPageWithLayout<P = {}, IP = P> = NextPage<P, IP> & {
 type AppPropsWithLayout = AppProps & {
   Component: NextPageWithLayout;
 };
-
-function getUniqueCharacters(str: string) {
-  return Array.from(
-    str
-      .split('')
-      .reduce((a, b) => {
-        a.set(b, true);
-        return a;
-      }, new Map<string, boolean>())
-      .keys()
-  ).sort();
-}
-
-// 使用している文字列のユニークな文字の配列
-const UDKakugoLargePr6HVStrings = getUniqueCharacters([entries.map((entry) => entry.description), pairs.map((pair) => pair.description)].flat().join('')).join('');
-const UDKakugoLargePr6EStrings = getUniqueCharacters(
-  [
-    '運　営',
-    '制　作',
-    '立ち絵',
-    '告　知',
-    '放　送',
-    '特別告知',
-    'コンビ告知',
-    '事前番組',
-    Object.entries(team).map(([, members]) => members.map((mem) => mem.name + mem.role)),
-    Object.entries(movies).map(([, movieArr]) => movieArr.map((mov) => mov.title)),
-    entries.map((entry) => entry.spDescription)
-  ]
-    .flat(4)
-    .join('')
-).join('');
 
 const pcPathFromSpPath = (path: string) => {
   const pcPath = path.replace('/sp', '');
@@ -138,27 +103,12 @@ function MyApp({ Component, pageProps }: AppPropsWithLayout) {
         <meta name="msapplication-TileColor" content="#da532c" />
         <meta name="theme-color" content="#ffffff" />
       </Head>
+      <style jsx global>{`
+        html {
+          font-family: ${notoSansJp.style.fontFamily};
+        }
+      `}</style>
       <Component {...pageProps} />
-      <div
-        className="hidden"
-        style={{
-          fontFamily: 'UDKakugo_LargePr6-HV',
-          lineHeight: '1.7'
-        }}
-        data-nosnippet
-      >
-        {UDKakugoLargePr6HVStrings}
-      </div>
-      <div
-        className="hidden"
-        style={{
-          fontFamily: 'FOT-UD角ゴ_ラージ Pr6 E',
-          lineHeight: '1.7'
-        }}
-        data-nosnippet
-      >
-        {UDKakugoLargePr6EStrings}
-      </div>
     </ParallaxProvider>
   );
 }

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -4,9 +4,6 @@ export default function Document() {
   return (
     <Html>
       <Head />
-      {/* eslint-disable-next-line @next/next/no-sync-scripts */}
-      <script src="https://webfont.fontplus.jp/accessor/script/fontplus.js?hYoxsp18w9g%3D&box=RdlEPoRA11s%3D&pm=1&aa=1&ab=2"></script>
-
       <body>
         <Main />
         <NextScript />


### PR DESCRIPTION
## 概要

FONTPLUS で配信していた FOT-UD角ゴ_ラージ Pr6 (E / HV) をやめ、源ノ角ゴシックの Google Fonts 配布版である Noto Sans JP を `next/font/google` でセルフホストするように置き換えた。

## 変更内容

- `src/libs/fonts.ts` を新規作成し、フォント指定をここに集約
  - 旧 E 相当 → `udKakugoLargeE` (weight 800)
  - 旧 HV 相当 → `udKakugoLargeHV` (weight 900)
  - 各コンポーネントの inline `fontFamily` 指定 (13箇所) はこれらの spread に置き換え
- `_document.tsx` から fontplus.js の script タグを削除
- `_app.tsx` から FONTPLUS の動的サブセット用の隠し div と文字列生成ロジックを削除し、`html` のデフォルトフォントを Noto Sans JP に設定
- 字詰め: `font-feature-settings: 'palt'` で約物・かなのプロポーショナル詰めを適用 (FONTPLUS の自動詰めの代替)
- 太さ: Noto Sans JP は可変フォントなので weight は 100〜900 の任意値で調整可能。HV 相当は軸上限の 900 を超えられないため `-webkit-text-stroke-width: 0.01em` でわずかに肉付け
- エントリー紹介モーダルの説明文サイズを 25px → 25.5px (vw 側も 25.5px 相当) に変更
- スナップショット更新

## 注意点

- 旧 UD角ゴ とは字形・字幅が異なるため、見た目の印象は変わる。ウェイトの対応 (E→800, HV→900) は推定マッピングなので、`src/libs/fonts.ts` の数値で追い込み可能
- フォント取得は build 時のみで、ランタイムの外部依存はなくなる

## 動作確認

- `yarn lint`: 新規エラーなし (warning は既存のみ)
- `yarn test`: 28 suites / 30 tests 全パス
- dev サーバーで `/`, `/team`, `/movies`, `/entries`, `/pairs`, `/sp/*` の表示と、`font-family` / `palt` / `text-stroke` の適用を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)